### PR TITLE
Fixed bug with flag & argument parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,8 +33,6 @@ func main() {
 	}
 	p := flag.Arg(0)
 
-	log.Printf("XXX maxStructWidth %d", *maxStructWidth)
-
 	fset := token.NewFileSet()
 
 	// TODO(#1): support '...' in filesystem dir

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	maxStructWidth = flag.Int64("max", 16, "maximum size in bytes a struct can be before by-value uses are flagged")
+	maxStructWidth = flag.Int64("maxx", 16, "maximum size in bytes a struct can be before by-value uses are flagged")
 	wordSize       = flag.Int64("wordSize", 8, "word size to assume when calculation struct size")
 	maxAlign       = flag.Int64("maxAlign", 8, "maximum word alignment to assume when calculating struct size")
 )
@@ -28,10 +28,12 @@ func main() {
 	log.SetFlags(0)
 	flag.Parse()
 
-	if len(os.Args) == 1 {
+	if flag.NArg() != 1 {
 		log.Fatalf("usage: %s GO_PKG_DIR", os.Args[0])
 	}
-	p := os.Args[1]
+	p := flag.Arg(0)
+
+	log.Printf("XXX maxStructWidth %d", *maxStructWidth)
 
 	fset := token.NewFileSet()
 

--- a/main.go
+++ b/main.go
@@ -240,6 +240,7 @@ func printSitesAndExit(sites []copySite, fset *token.FileSet) {
 	sort.Sort(sortedCopySites{sites: sites, fset: fset})
 	for _, site := range sites {
 		f := site.fun
+		p := fset.Position(f.Pos())
 		shouldBe := site.shouldBe
 		sb := sentence(shouldBe)
 		msg := "should be made into"
@@ -248,8 +249,7 @@ func printSitesAndExit(sites []copySite, fset *token.FileSet) {
 		} else {
 			msg += " a pointer"
 		}
-		fmt.Println("#", sb, msg)
-		fmt.Printf("%s\n\n", f)
+		fmt.Printf("%s:%d:%s: %s %s\n", p.Filename, p.Line, f, sb, msg)
 	}
 	if len(sites) > 0 {
 		os.Exit(2)

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	maxStructWidth = flag.Int64("maxx", 16, "maximum size in bytes a struct can be before by-value uses are flagged")
+	maxStructWidth = flag.Int64("max", 16, "maximum size in bytes a struct can be before by-value uses are flagged")
 	wordSize       = flag.Int64("wordSize", 8, "word size to assume when calculation struct size")
 	maxAlign       = flag.Int64("maxAlign", 8, "maximum word alignment to assume when calculating struct size")
 )


### PR DESCRIPTION
Using flags with the program would fail due to a parsing bug : the program was mixing raw extraction of the first argument with the "os" package (for the main path) with "flag" package parsing (for the various flags). These 2 approaches are incompatible with each other.
This patch performs all the parsing through the "flag" package.
