### PR TITLE
Switch to a more parseable format

### DIFF
--- a/main.go
+++ b/main.go
@@ -248,8 +248,10 @@ func printSitesAndExit(sites []copySite, fset *token.FileSet) {
 		} else {
 			msg += " a pointer"
 		}
-		fmt.Println("#", sb, msg)
-		fmt.Printf("%s\n\n", f)
+		pos := site.fun.Pos()
+		file := fset.File(pos)
+		position := file.Position(pos)
+		fmt.Printf("%s:%d:%d: %s %s (%s)\n", file.Name(), position.Line, position.Column, sb, msg, f)
 	}
 	if len(sites) > 0 {
 		os.Exit(2)


### PR DESCRIPTION
Allows for better integration with other tools, editors, etc.

Fixes #4 and potentially #2.

It gives output like this:

```
$ copyfighter ./testdata
testdata/inner.go:24:6: parameter 'f' at index 0 should be made into a pointer (func CallsFoo(f Foo))
testdata/inner.go:28:14: receiver, and parameter 'o' at index 0 should be made into pointers (func (Foo).OnOtherToo(o other))
testdata/inner.go:32:16: receiver should be made into a pointer (func (other).OnStruct())
testdata/inner.go:35:16: receiver should be made into a pointer (func (other).OnStruct2())
```
