### PR TITLE
Skip files not matching build constraints

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,10 @@ func parsePkgDir(p string, fset *token.FileSet) (*ast.Package, error) {
 	}
 
 	buildContext := build.Default
-	bpkg, _ := buildContext.ImportDir(p, 0)
+	bpkg, err := buildContext.ImportDir(p, 0)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse package at %#v: %s", p, err)
+	}
 
 	mp, err := parser.ParseDir(fset, p, func(i os.FileInfo) bool {
 		for _, f := range bpkg.IgnoredGoFiles {

--- a/main.go
+++ b/main.go
@@ -90,7 +90,22 @@ func parsePkgDir(p string, fset *token.FileSet) (*ast.Package, error) {
 		return nil, fmt.Errorf("%#v is not a directory", p)
 	}
 
-	mp, err := parser.ParseDir(fset, p, nil, 0)
+	buildContext := build.Default
+	bpkg, _ := buildContext.ImportDir(p, 0)
+
+	mp, err := parser.ParseDir(fset, p, func(i os.FileInfo) bool {
+		for _, f := range bpkg.IgnoredGoFiles {
+			if f == i.Name() {
+				return false
+			}
+		}
+		for _, f := range bpkg.InvalidGoFiles {
+			if f == i.Name() {
+				return false
+			}
+		}
+		return true
+	}, 0)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse package at %#v: %s", p, err)
 	}

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/build"
-	"go/importer"
 	"go/parser"
 	"go/token"
 	"go/types"
@@ -16,6 +15,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"golang.org/x/tools/go/gcexportdata"
 )
 
 var (
@@ -172,10 +173,11 @@ func checkPkg(pkg *ast.Package, fset *token.FileSet, maxWidth, wordSize, maxAlig
 		Types: make(map[ast.Expr]types.TypeAndValue),
 		Defs:  make(map[*ast.Ident]types.Object),
 	}
+
 	conf := &types.Config{
-		Importer:                 importer.Default(),
+		Importer:                 gcexportdata.NewImporter(fset, make(map[string]*types.Package)),
 		DisableUnusedImportCheck: true,
-		Sizes: sizes,
+		Sizes:                    sizes,
 	}
 	files := []*ast.File{}
 	for _, f := range pkg.Files {


### PR DESCRIPTION
 skip files ignored by build contraints

parser.ParseDir does not honor build constraints but buildContext.ImportDir does. So we use
that list of ignored files to filter the parser.ParseDir.

fixes:
    - GH-6

Signed-off-by: Sven Nierlein <sven@nierlein.de>