### PR TITLE
Fix Sizeof panic on Go 1.25+ for non-struct types

### DIFF
--- a/main.go
+++ b/main.go
@@ -212,8 +212,12 @@ func checkPkg(pkg *ast.Package, fset *token.FileSet, maxWidth, wordSize, maxAlig
 	funcs := []*types.Func{}
 	for _, obj := range info.Defs {
 		if tn, ok := obj.(*types.TypeName); ok {
-			if sizes.Sizeof(tn.Type()) > maxWidth {
-				wideStructs[tn.Id()] = true
+			// Only compute Sizeof for struct types. Sizeof panics on
+			// interfaces and other non-concrete types in Go 1.25+.
+			if _, isStruct := tn.Type().Underlying().(*types.Struct); isStruct {
+				if sizes.Sizeof(tn.Type()) > maxWidth {
+					wideStructs[tn.Id()] = true
+				}
 			}
 		}
 		if f, ok := obj.(*types.Func); ok {


### PR DESCRIPTION
## Summary
- `go/types.(*StdSizes).Sizeof` panics with an assertion failure when called on interface types and other non-concrete types in Go 1.25+
- `checkPkg` iterates over all `TypeName` definitions and calls `Sizeof` unconditionally, but copyfighter only cares about large **structs** passed by value
- Guard the `Sizeof` call to only run on struct types (via `tn.Type().Underlying().(*types.Struct)` type assertion)

## Reproduction
Any Go package that defines or imports interface types will cause a panic when analyzed with copyfighter under Go 1.25+:
```
panic: .../go/types/sizes.go:224: assertion failed
```

## Fix
Check that the type's underlying type is a `*types.Struct` before calling `Sizeof`. This is semantically correct since copyfighter only flags structs that are too large to pass by value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)