### PR TITLE
fix issue with structs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/jmhodges/copyfighter
+
+go 1.22
+
+require golang.org/x/tools v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
+golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.13.0 h1:Iey4qkscZuv0VvIt8E0neZjtPVQFSc870HQ448QgEmQ=
+golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=

--- a/main.go
+++ b/main.go
@@ -212,8 +212,10 @@ func checkPkg(pkg *ast.Package, fset *token.FileSet, maxWidth, wordSize, maxAlig
 	funcs := []*types.Func{}
 	for _, obj := range info.Defs {
 		if tn, ok := obj.(*types.TypeName); ok {
-			if sizes.Sizeof(tn.Type()) > maxWidth {
-				wideStructs[tn.Id()] = true
+			if _, ok := tn.Type().Underlying().(*types.Struct); ok {
+				if sizes.Sizeof(tn.Type()) > maxWidth {
+					wideStructs[tn.Id()] = true
+				}
 			}
 		}
 		if f, ok := obj.(*types.Func); ok {


### PR DESCRIPTION
Fixes this issue:
```golang
panic: /usr/lib/go-1.22/src/go/types/sizes.go:223: assertion failed

goroutine 1 [running]:
go/types.assert(0xf0?)
        /usr/lib/go-1.22/src/go/types/errors.go:28 +0x54
go/types.(*StdSizes).Sizeof(0xc00018efe0, {0x6b77f0, 0xc0004fe690})
        /usr/lib/go-1.22/src/go/types/sizes.go:223 +0x185
main.checkPkg(0xc0001b9e90, 0xc000122280, 0x10, 0x8, 0x8)
        /home/user/git/jmhodges/copyfighter/main.go:215 +0x535
main.check({0x7ffeba8d2adf, 0x1}, 0x10, 0x8, 0x8)
        /home/user/git/jmhodges/copyfighter/main.go:74 +0xf7
main.main()
        /home/user/git/jmhodges/copyfighter/main.go:37 +0x13e
```
It was trying to get the size of a struct on an object that isn't a struct.

Additionally had to build with `go 1.22` and `golang.org/x/tools v0.13.0` to get it to compile.
