### PR TITLE
Upgrade golang.org/x/tools to v0.49.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/jmhodges/copyfighter
 
-go 1.22
+go 1.25.0
 
-require golang.org/x/tools v0.13.0
+require golang.org/x/tools v0.49.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
-golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
-golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
-golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
-golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.13.0 h1:Iey4qkscZuv0VvIt8E0neZjtPVQFSc870HQ448QgEmQ=
-golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.39.0 h1:UF5zwQdCRRUpHfyPwr7d4UrGiVeldIsogtzWVnczL74=
+golang.org/x/mod v0.39.0/go.mod h1:bvIbwjQ0HUFFf5AKukeeYQG4ZBUG9yxQbR9aEweIwYY=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.49.0 h1:3NI7VXzL9+1WZD52Dx2ttoPwD5DWrFGpl9mFZDlmisI=
+golang.org/x/tools v0.49.0/go.mod h1:SJNXV9DBKT0UbdttsQjbfJlAE/q+y36++zo3uL3N0Oo=


### PR DESCRIPTION
The pinned `golang.org/x/tools v0.13.0` is from 2023, and its `gcexportdata` can no longer read the export data written by current Go toolchains. On go1.24.7 the test suite fails outright:

```
--- FAIL: TestGoldenPath (6.80s)
    check_test.go:11: unexpected error: unable to type check package "main":
    testdata/inner.go:3:8: could not import net/http (reading export data:
    internal error in importing "net/http" (unsupported version: 2);
    please report an issue)
```

copyfighter type checks packages from their compiled export data, so x/tools has to stay roughly contemporaneous with the toolchain that did the compiling. This is the recurring failure mode for this tool, and it currently means copyfighter doesn't work on any recent Go.

## Changes

- `golang.org/x/tools` v0.13.0 → v0.49.0
- `go mod tidy`

## Note on the go directive

x/tools v0.49.0 declares `go 1.25.0`, so the module's own `go` directive moves from `1.22` to `1.25.0`. That's forced by the dependency, not a choice — worth knowing since it raises the minimum toolchain for building copyfighter from source. Happy to pin an older x/tools instead if you'd rather keep a lower floor, though the older ones are what caused the breakage.

## Testing

On go1.24.7:

- `go vet ./...` — clean
- `go test ./...` — `ok github.com/jmhodges/copyfighter 5.255s`
- Smoke test of the built binary against `./testdata` produces the expected four findings:

```
testdata/inner.go:24:6: parameter 'f' at index 0 should be made into a pointer (func CallsFoo(f Foo))
testdata/inner.go:28:14: receiver, and parameter 'o' at index 0 should be made into pointers (func (Foo).OnOtherToo(o other))
testdata/inner.go:32:16: receiver should be made into a pointer (func (other).OnStruct())
testdata/inner.go:35:16: receiver should be made into a pointer (func (other).OnStruct2())
```

There is no CI on this repo right now, so those were run by hand — #18 adds a workflow, stacked on this branch.