### PR TITLE
Add Dependabot config for Go modules and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # copyfighter reads packages' compiled export data via gcexportdata, so
+  # golang.org/x/tools has to stay roughly contemporaneous with the Go
+  # toolchain. Letting it drift is what broke the build before.
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Adds `.github/dependabot.yml` with weekly updates for two ecosystems.

## Why

This is the same problem #17 just fixed, aimed at preventing the next one. copyfighter type checks packages from their compiled export data via `gcexportdata`, so `golang.org/x/tools` has to stay roughly contemporaneous with the toolchain that compiled them. The pin sat at v0.13.0 for two years and the build was broken the whole time with nothing to surface it — no commits, no CI, no signal. Weekly `gomod` PRs make that drift visible while it's still a one-line bump.

`github-actions` is included to keep the workflow's own action versions from going stale the same way.

## Note on ordering

The `github-actions` ecosystem has nothing to scan until #18 merges and `.github/workflows/ci.yml` exists on `master`. Dependabot just finds no manifests for it until then — harmless, and it starts working on its own once #18 lands. The `gomod` half works immediately. The two PRs are independent and touch different files, so they can merge in either order.

## Testing

The YAML parses and matches Dependabot's v2 schema (`version: 2`, `updates[]` with `package-ecosystem`/`directory`/`schedule`). Beyond that it isn't verifiable from here — GitHub validates the file on push, and the result shows under Insights → Dependency graph → Dependabot. Worth a look after merge to confirm both ecosystems registered.