### PR TITLE
Derive the CI Go matrix from go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,37 @@ permissions:
   contents: read
 
 jobs:
+  go-versions:
+    # The test matrix is derived from go.mod rather than hard-coded, so bumping
+    # the `go` directive automatically moves the oldest tested toolchain along
+    # with it. Nothing in this file needs editing when that happens.
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: matrix
+        run: |
+          set -euo pipefail
+          # "go 1.25.0" -> "1.25". Also handles "go 1.25" and "go 1.25rc1".
+          minor="$(sed -nE 's/^go[[:space:]]+([0-9]+\.[0-9]+).*$/\1/p' go.mod | head -n1)"
+          if [ -z "$minor" ]; then
+            echo "::error file=go.mod::could not find a 'go' directive in go.mod" >&2
+            exit 1
+          fi
+          # The oldest toolchain go.mod allows (latest patch of that minor),
+          # plus the current release.
+          matrix="[\"${minor}.x\", \"stable\"]"
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          echo "Go test matrix: ${matrix}"
+
   test:
+    needs: go-versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        # The oldest toolchain go.mod allows, plus the current release.
-        go-version: ['1.25.x', 'stable']
+        go-version: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
     name: test (go ${{ matrix.go-version }})
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
The oldest Go version in the test matrix was hard-coded in `ci.yml`, so every bump of the `go` directive in `go.mod` needed a matching hand edit.

This adds a small `go-versions` job that reads the directive out of `go.mod` and emits the matrix as a job output: the latest patch of that minor (e.g. `1.25.x`) plus `stable`. The `test` job consumes it via `fromJSON`. Bumping `go.mod` now moves the oldest tested toolchain along with it on the same push, with nothing in the workflow to keep in sync.

Notes:
- The extractor handles `go 1.25.0`, `go 1.25`, and `go 1.25rc1`, and ignores a `toolchain` line.
- Check names are unchanged (`test (go 1.25.x)`, `test (go stable)`), so existing branch protection still matches. `go-versions` appears as one extra check.
- If `go.mod` ever points at the same minor as current stable, the two matrix entries resolve to the same toolchain and you get two identical jobs. Harmless, so there's no dedupe logic.

Doing this at run time instead of with a separate "when go.mod changes, edit ci.yml" workflow avoids needing a PAT or GitHub App for the bot PR to trigger CI, and avoids always being one commit behind.