### PR TITLE
Trigger CI on pushes to main instead of master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
   # copyfighter type checks packages from their compiled export data, so it
   # tends to break when a new Go toolchain ships rather than when this repo


### PR DESCRIPTION
The default branch has been renamed from `master` to `main`. The `push` trigger in `.github/workflows/ci.yml` was the only reference to the old name anywhere in the tree, so this is the whole diff. Without it, pushes to `main` don't run CI; PR, scheduled, and manual runs are unaffected either way.