### PR TITLE
Fix panic on packages that declare generic structs

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -261,6 +261,86 @@ src.go:5:6: parameter 'b' at index 0 should be made into a pointer (func Y(b big
 	}
 }
 
+// Generic structs have no size until they are instantiated, and asking
+// go/types for the size of a type parameter panics. Uses with concrete type
+// arguments are sized and reported; uses that still mention a type parameter
+// are skipped.
+func TestCheckGenericStructs(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "instantiation is sized with its type arguments",
+			src: `package p
+type G[T any] struct{ a, b, c T }
+func F(g G[int64]) {}
+func H(g G[byte]) {}
+`,
+			want: "src.go:3:6: parameter 'g' at index 0 should be made into a pointer (func F(g G[int64]))\n",
+		},
+		{
+			name: "generic method receiver and signature are skipped",
+			src: `package p
+type G[T any] struct{ a, b, c T }
+func (g G[T]) M(o G[T]) G[T] { return o }
+`,
+			want: "",
+		},
+		{
+			name: "receiver whose size does not depend on the type parameter is reported",
+			src: `package p
+type P[T comparable] struct{ p *T; s []T; m map[T]T; a, b int64 }
+func (p P[T]) M() {}
+`,
+			want: "src.go:3:15: receiver should be made into a pointer (func (P[T]).M())\n",
+		},
+		{
+			name: "array of the type parameter",
+			src: `package p
+type A[T any] struct{ arr [4]T }
+func (a A[T]) M() {}
+func F(a A[int64], b A[byte]) {}
+`,
+			want: "src.go:4:6: parameter 'a' at index 0 should be made into a pointer (func F(a A[int64], b A[byte]))\n",
+		},
+		{
+			name: "generic struct nested in another generic struct",
+			src: `package p
+type G[T any] struct{ a, b, c T }
+type Outer[T any] struct{ g G[T] }
+func (o Outer[T]) M() {}
+func F(o Outer[int64]) {}
+`,
+			want: "src.go:5:6: parameter 'o' at index 0 should be made into a pointer (func F(o Outer[int64]))\n",
+		},
+		{
+			name: "struct declared inside a generic function",
+			src: `package p
+func F[T any]() { type inner struct{ a, b, c T }; _ = inner{} }
+`,
+			want: "",
+		},
+		{
+			name: "interface methods",
+			src: `package p
+type G[T any] struct{ a, b, c T }
+type I[T any] interface{ M(G[T]) }
+type J interface{ M(G[int64]) }
+`,
+			want: "src.go:4:19: parameter at index 0 should be made into a pointer (func (J).M(G[int64]))\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if actual := checkSource(t, tt.src); actual != tt.want {
+				t.Errorf("want:\n%s\n=============\ngot:\n%s", tt.want, actual)
+			}
+		})
+	}
+}
+
 // Files excluded by build constraints must not be parsed or type checked, or a
 // package could never be checked on a platform it isn't targeting.
 func TestCheckSkipsFilesExcludedByBuildConstraints(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -207,15 +207,17 @@ func checkPkg(pkg *ast.Package, fset *token.FileSet, maxWidth, wordSize, maxAlig
 		return nil, fmt.Errorf("unable to type check package %#v: %s", pkg.Name, err)
 	}
 
-	wideStructs := make(map[string]bool)
+	checker := &wideStructChecker{
+		sizes:        sizes,
+		maxWidth:     maxWidth,
+		localStructs: make(map[*types.TypeName]bool),
+	}
 
 	funcs := []*types.Func{}
 	for _, obj := range info.Defs {
 		if tn, ok := obj.(*types.TypeName); ok {
 			if _, ok := tn.Type().Underlying().(*types.Struct); ok {
-				if sizes.Sizeof(tn.Type()) > maxWidth {
-					wideStructs[tn.Id()] = true
-				}
+				checker.localStructs[tn] = true
 			}
 		}
 		if f, ok := obj.(*types.Func); ok {
@@ -223,15 +225,14 @@ func checkPkg(pkg *ast.Package, fset *token.FileSet, maxWidth, wordSize, maxAlig
 		}
 	}
 
-	sites := findCopySites(funcs, wideStructs)
+	sites := findCopySites(funcs, checker)
 
 	return sites, nil
 }
 
 // findCopySites returns a slice of copySites that represent Go function calls
-// that use a large struct without a pointer to it. The wideStructs argument is
-// a map of the struct's TypeName id to its TypeName object.
-func findCopySites(funcs []*types.Func, wideStructs map[string]bool) []copySite {
+// that use a large struct without a pointer to it.
+func findCopySites(funcs []*types.Func, checker *wideStructChecker) []copySite {
 	sites := []copySite{}
 	for _, f := range funcs {
 		s := f.Type().(*types.Signature)
@@ -240,7 +241,7 @@ func findCopySites(funcs []*types.Func, wideStructs map[string]bool) []copySite 
 		// If the func is a method, check the receiver
 		if s.Recv() != nil {
 			rt := s.Recv().Type()
-			if isWideStructTyped(rt, wideStructs) {
+			if checker.isWide(rt) {
 				shouldBe = append(shouldBe, "receiver")
 			}
 		}
@@ -248,7 +249,7 @@ func findCopySites(funcs []*types.Func, wideStructs map[string]bool) []copySite 
 		params := s.Params()
 		for i := 0; i < params.Len(); i++ {
 			v := params.At(i)
-			if isWideStructTyped(v.Type(), wideStructs) {
+			if checker.isWide(v.Type()) {
 				name := v.Name()
 				parameter := "parameter"
 				if name != "" {
@@ -262,7 +263,7 @@ func findCopySites(funcs []*types.Func, wideStructs map[string]bool) []copySite 
 		results := s.Results()
 		for i := 0; i < results.Len(); i++ {
 			v := results.At(i)
-			if isWideStructTyped(v.Type(), wideStructs) {
+			if checker.isWide(v.Type()) {
 				shouldBe = append(shouldBe,
 					fmt.Sprintf("return value '%s' at index %d", v.Type(), i))
 			}
@@ -325,11 +326,57 @@ func (s sortedCopySites) Less(i, j int) bool {
 	return left.Column < right.Column
 }
 
-// isWideStructTyped returns true if the given type is a struct (not a pointer to
-// a struct) that is in wideStructs.
-func isWideStructTyped(t types.Type, wideStructs map[string]bool) bool {
-	if named, ok := t.(*types.Named); ok {
-		return wideStructs[named.Obj().Id()]
+// wideStructChecker decides whether a type is a struct defined in the package
+// being checked that is too wide to be passed around by value.
+type wideStructChecker struct {
+	sizes    types.Sizes
+	maxWidth int64
+	// localStructs holds the named struct types declared in the package being
+	// checked. Only those are reported.
+	localStructs map[*types.TypeName]bool
+}
+
+// isWide returns true if the given type is a struct (not a pointer to a
+// struct) declared in the package being checked and wider than maxWidth.
+func (c *wideStructChecker) isWide(t types.Type) bool {
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	// For an instantiated generic type, Obj returns the type name of the
+	// generic declaration, so this matches G[int] to G.
+	if !c.localStructs[named.Obj()] {
+		return false
+	}
+	// A generic struct has no size until it is instantiated with concrete
+	// types, and the sizer panics on a type parameter. That rules out the
+	// declaration itself and a generic method's receiver, both of which are
+	// still written in terms of the struct's type parameters.
+	if hasTypeParam(named) {
+		return false
+	}
+	return c.sizes.Sizeof(t) > c.maxWidth
+}
+
+// hasTypeParam returns true if computing the size of t would require the size
+// of a type parameter. It only descends into the parts of a type that
+// contribute to its size: struct fields, array elements, and the underlying
+// types of named types. Anything behind a pointer, slice, map, channel,
+// function, or interface has a fixed size and is not visited.
+func hasTypeParam(t types.Type) bool {
+	switch t := t.(type) {
+	case *types.TypeParam:
+		return true
+	case *types.Named:
+		return hasTypeParam(t.Underlying())
+	case *types.Array:
+		return hasTypeParam(t.Elem())
+	case *types.Struct:
+		for i := 0; i < t.NumFields(); i++ {
+			if hasTypeParam(t.Field(i).Type()) {
+				return true
+			}
+		}
 	}
 	return false
 }


### PR DESCRIPTION
`checkPkg` asked go/types for the size of every struct type declared in the package, and `StdSizes.Sizeof` panics when it reaches a type parameter. Any package with a generic struct crashed copyfighter:

```
panic: .../go/types/sizes.go:92: assertion failed
```

Sizes are now computed where a type is used rather than where it is declared, so an instantiation like `G[int64]` is sized with its type arguments and reported when it is wide. Uses that still mention a type parameter (the declaration itself, a generic method's receiver) cannot be sized and are skipped, unless the parameter only appears behind a pointer, slice, map, channel, function, or interface, where it does not affect the size and the struct is still reported.

The set of local struct types is now keyed by the `*types.TypeName` object rather than its `Id()` string. `Obj()` on an instantiated type returns the generic declaration's `TypeName`, which makes the lookup work for instantiations, and as a side effect it stops an unexported local type from colliding with an exported type of the same name from another package.

`TestCheckGenericStructs` covers instantiations, generic receivers, arrays of and nesting of the type parameter, a struct declared inside a generic function, and interface methods. It panics on `main` without the fix.

<!-- stack-map -->
**Stacked PR** — part 1 of 2, review bottom-up. (#22, the tests this builds on, has merged.)
1. **this PR — fix generic struct panic**
2. #24 — flag aliases of wide structs (stacked on this)
<!-- /stack-map -->