### PR TITLE
feat(max): Bump the default width limit to 64 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,32 +17,33 @@ Install with `go get` or similar.
 
 Example output
 ---------------
-    $ copyfighter /gopath/path/to/pkg
-    # parameter 'f' at index 0 should be made into a pointer
-    func CallsFoo(f Foo)
-    
-    # receiver, and parameter 'o' at index 0 should be made into pointers
-    func (Foo).OnOtherToo(o other)
-    
-    # receiver should be made into a pointer
-    func (other).OnStruct()
-    
-    # receiver should be made into a pointer
-    func (other).OnStruct2()
+    $ copyfighter path/to/pkg
+    path/to/pkg/config.go:59:6: parameter 'c' at index 0 should be made into a pointer (func Configure(c config))
+    path/to/pkg/config.go:63:17: receiver should be made into a pointer (func (config).Validate())
 
     $ copyfighter -max 32 path/to/pkg
-    # parameter 'f' at index 0 should be made into a pointer
-    func CallsFoo(f Foo)
-
-    # receiver should be made into a pointer
-    func (Foo).OnOtherToo(o other)
+    path/to/pkg/client.go:24:6: parameter 'f' at index 0 should be made into a pointer (func CallsFoo(f Foo))
+    path/to/pkg/client.go:28:14: receiver should be made into a pointer (func (Foo).OnOtherToo(o other))
+    path/to/pkg/config.go:59:6: parameter 'c' at index 0 should be made into a pointer (func Configure(c config))
+    path/to/pkg/config.go:63:17: receiver should be made into a pointer (func (config).Validate())
 
 Defaults And Flags
 ------------------
 
-By default, copyfighter assumes structs wider than 16 bytes (two words on x86\_64) should
-not be copied. This can be adjusted with the `-max` flag. `max` should typically
-be set to some multiple of the word size. You can also adjust the word size and alignment offset for your preferred architecture with `-wordSize` and `-maxAlign`.
+By default, copyfighter assumes structs wider than 64 bytes (eight words on
+x86\_64) should not be copied. That's where the Go compiler stops copying a
+struct inline and starts calling out to a copy routine, on both amd64 and
+arm64. Smaller structs are cheap to copy and usually get passed in registers
+anyway. Use the `-max` flag to change it. `max` should typically be set to some
+multiple of the word size. You can also adjust the word size and alignment
+offset for your preferred architecture with `-wordSize` and `-maxAlign`.
+
+The defaults work as-is on 64-bit ARM. Same word size, same alignment, same
+64 byte cutoff in the compiler. arm64 does hand out 16 integer registers for
+arguments where amd64 has 9, so up to 128 bytes of ints and pointers can go
+through a call without touching memory. If that's all you care about, `-max
+128` is fine, but anything over 64 bytes still hits the copy routine every
+time it's assigned or returned.
 
 Flags like `-max` have to go before the package name.
 

--- a/check_test.go
+++ b/check_test.go
@@ -26,6 +26,14 @@ const goldenData = `testdata/inner.go:24:6: parameter 'f' at index 0 should be m
 testdata/inner.go:28:14: receiver, and parameter 'o' at index 0 should be made into pointers (func (Foo).OnOtherToo(o other))
 testdata/inner.go:32:16: receiver should be made into a pointer (func (other).OnStruct())
 testdata/inner.go:35:16: receiver should be made into a pointer (func (other).OnStruct2())
+testdata/inner.go:59:6: parameter 'c' at index 0 should be made into a pointer (func Configure(c config))
+testdata/inner.go:63:17: receiver should be made into a pointer (func (config).Validate())
+`
+
+// defaultGoldenData is the output for testdata under the default limit of 64
+// bytes, which only config exceeds.
+const defaultGoldenData = `testdata/inner.go:59:6: parameter 'c' at index 0 should be made into a pointer (func Configure(c config))
+testdata/inner.go:63:17: receiver should be made into a pointer (func (config).Validate())
 `
 
 // The sites come out of checkPkg in map iteration order, so printSites has to
@@ -51,8 +59,9 @@ func TestPrintSitesSortsByPosition(t *testing.T) {
 	}
 }
 
-// In testdata, Foo is an http.Client (hundreds of bytes) and other is exactly
-// 32 bytes on a 64-bit word size: an int64, a pointer, and an interface.
+// In testdata on a 64-bit word size, Foo is an http.Client (48 bytes), other is
+// exactly 32 bytes (an int64, a pointer, and an interface), and config is 72
+// bytes (two strings, two int64s, and a slice).
 func TestMaxStructWidth(t *testing.T) {
 	tests := []struct {
 		name string
@@ -60,7 +69,12 @@ func TestMaxStructWidth(t *testing.T) {
 		want string
 	}{
 		{
-			name: "default flags everything wider than two words",
+			name: "default flags only structs wider than 64 bytes",
+			max:  *maxStructWidth,
+			want: defaultGoldenData,
+		},
+		{
+			name: "two words flags everything in testdata",
 			max:  16,
 			want: goldenData,
 		},
@@ -69,6 +83,8 @@ func TestMaxStructWidth(t *testing.T) {
 			max:  32,
 			want: `testdata/inner.go:24:6: parameter 'f' at index 0 should be made into a pointer (func CallsFoo(f Foo))
 testdata/inner.go:28:14: receiver should be made into a pointer (func (Foo).OnOtherToo(o other))
+testdata/inner.go:59:6: parameter 'c' at index 0 should be made into a pointer (func Configure(c config))
+testdata/inner.go:63:17: receiver should be made into a pointer (func (config).Validate())
 `,
 		},
 		{
@@ -99,7 +115,8 @@ testdata/inner.go:28:14: receiver should be made into a pointer (func (Foo).OnOt
 
 // With 4 byte words the other struct in testdata shrinks from 32 bytes to 20
 // (int64 + pointer + interface), so a limit of 24 bytes flags it on a 64-bit
-// word size but not on a 32-bit one.
+// word size but not on a 32-bit one. Foo (28 bytes) and config (44 bytes) are
+// still over the limit.
 func TestWordSize(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -118,6 +135,8 @@ func TestWordSize(t *testing.T) {
 			maxAlign: 4,
 			want: `testdata/inner.go:24:6: parameter 'f' at index 0 should be made into a pointer (func CallsFoo(f Foo))
 testdata/inner.go:28:14: receiver should be made into a pointer (func (Foo).OnOtherToo(o other))
+testdata/inner.go:59:6: parameter 'c' at index 0 should be made into a pointer (func Configure(c config))
+testdata/inner.go:63:17: receiver should be made into a pointer (func (config).Validate())
 `,
 		},
 	}
@@ -137,8 +156,8 @@ testdata/inner.go:28:14: receiver should be made into a pointer (func (Foo).OnOt
 }
 
 // checkSource writes src to a fresh directory as a single Go file, runs check
-// over it with the default flags, and returns the printed output with the
-// temporary file path replaced by "src.go".
+// over it with a 16 byte limit and 64-bit words, and returns the printed output
+// with the temporary file path replaced by "src.go".
 func checkSource(t *testing.T, src string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	maxStructWidth = flag.Int64("max", 16, "maximum size in bytes a struct can be before by-value uses are flagged")
+	maxStructWidth = flag.Int64("max", 64, "maximum size in bytes a struct can be before by-value uses are flagged")
 	wordSize       = flag.Int64("wordSize", 8, "word size to assume when calculation struct size")
 	maxAlign       = flag.Int64("maxAlign", 8, "maximum word alignment to assume when calculating struct size")
 )

--- a/main_test.go
+++ b/main_test.go
@@ -32,7 +32,7 @@ func TestCLI(t *testing.T) {
 			name:       "copy sites found",
 			args:       []string{"./testdata"},
 			wantCode:   2,
-			wantStdout: goldenData,
+			wantStdout: defaultGoldenData,
 		},
 		{
 			name:     "flags before the package narrow the results",
@@ -40,6 +40,8 @@ func TestCLI(t *testing.T) {
 			wantCode: 2,
 			wantStdout: `testdata/inner.go:24:6: parameter 'f' at index 0 should be made into a pointer (func CallsFoo(f Foo))
 testdata/inner.go:28:14: receiver should be made into a pointer (func (Foo).OnOtherToo(o other))
+testdata/inner.go:59:6: parameter 'c' at index 0 should be made into a pointer (func Configure(c config))
+testdata/inner.go:63:17: receiver should be made into a pointer (func (config).Validate())
 `,
 		},
 		{
@@ -48,6 +50,8 @@ testdata/inner.go:28:14: receiver should be made into a pointer (func (Foo).OnOt
 			wantCode: 2,
 			wantStdout: `testdata/inner.go:24:6: parameter 'f' at index 0 should be made into a pointer (func CallsFoo(f Foo))
 testdata/inner.go:28:14: receiver should be made into a pointer (func (Foo).OnOtherToo(o other))
+testdata/inner.go:59:6: parameter 'c' at index 0 should be made into a pointer (func Configure(c config))
+testdata/inner.go:63:17: receiver should be made into a pointer (func (config).Validate())
 `,
 		},
 		{

--- a/testdata/inner.go
+++ b/testdata/inner.go
@@ -45,3 +45,21 @@ func (o *other) OnPtr2() {
 func (o *other) OnPtr3() {
 
 }
+
+// config is 72 bytes on a 64-bit word size: two strings, two int64s, and a
+// slice. It is the only struct in this package wider than the default limit.
+type config struct {
+	name    string
+	addr    string
+	timeout int64
+	retries int64
+	tags    []string
+}
+
+func Configure(c config) {
+
+}
+
+func (c config) Validate() {
+
+}


### PR DESCRIPTION
## Why

The 16 byte default for `-max` dates from the 2015 initial commit, when Go still passed every argument on the stack and two words was a defensible line. It hasn't been revisited since, and it now flags any struct holding a slice, a string plus anything, an interface plus anything, or three ints. Idiomatic Go passes all of those by value.

What changed underneath it:

- **Register ABI (Go 1.17+).** On amd64 a struct is split into fields and passed in up to 9 integer registers, so up to 72 bytes of pointer or int shaped fields never touch memory on the call. arm64 has 16 registers, so 128 bytes.
- **Compiler copy lowering.** On both amd64 and arm64, moves of 64 bytes or less are inlined as a few instructions. Above 64 bytes the compiler switches to a Duff's device call. 64 is where a copy stops being a handful of instructions.
- **Ecosystem.** gocritic's equivalent `hugeParam` check defaults to 80 bytes.

64 lines up with the compiler's inline copy cutoff on both architectures and is a multiple of the word size, as the README already advises.

## What

- `main.go`: default `-max` is now 64.
- `README.md`: updated the defaults paragraph with the new number and a short rationale, added a paragraph on arm64 (same word size, alignment, and copy cutoff, so the default and the `-wordSize`/`-maxAlign` flags need no changes; `-max 128` is an option if you only care about the register budget), and regenerated the example output from what the tool actually prints today (the old example used an output format the tool no longer produces).
- `testdata/inner.go`: nothing in testdata was wider than 64 bytes (`Foo` is an `http.Client`, which is 48 bytes, not "hundreds" as the old test comment claimed), so the default would have flagged nothing. Added a 72 byte `config` struct with a by-value parameter and receiver so the default is still exercised.
- `check_test.go`, `main_test.go`: new `defaultGoldenData` for the 64 byte default, existing goldens gain the two `config` sites, and the `TestMaxStructWidth` default case now reads the flag's actual default instead of hardcoding 16. Fixed the struct size comments.

`gofmt`, `go vet`, and `go test ./...` are clean.